### PR TITLE
Updated configuration for Crowdin-GitHub integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,3 @@
+files:
+  - source: /src/content/en/**/*.*
+    translation: /src/content/%locale%/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,24 @@
 files:
   - source: /src/content/en/**/*.*
     translation: /src/content/%locale%/**/%original_file_name%
+    languages_mapping:
+      locale:
+        ar: ar
+        zh-CN: zh-cn
+        zh-TW: zh-tw
+        nl: nl
+        fr: fr
+        de: de
+        he: he
+        hi: hi
+        id: id
+        it: it
+        ja: ja
+        ko: ko
+        pl: pl
+        pt-BR: pt-br
+        ru: ru
+        es-ES: es
+        th: th
+        tr: tr
+        vi: vi


### PR DESCRIPTION
What's changed, or what was fixed?
- valid path to source/translated files is defined
- added proper languages mapping to match existing languages

**Fixes:** Languages export

**Target Live Date:** 2019-02-08

- [x] This has been reviewed and approved by Andriy from Crowdin

**CC:** @petele